### PR TITLE
bumping version to start PR branch etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-apply-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "2.0.4",
+  "version": "2.0.6",
   "homepage": "https://github.com/DEFRA/ffc-demo-apply-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current k8s ingress is on http due to product support/configuration of existing WAF. The WAF is being modernised/upgraded and this configuration will be uplifted at the same time. The intent is to expose both http and https ingresses to allow for cut over. 

Though the certificate will be self-signed on the final hop, the client side traffic will be on a typical CA signed cert as it is today.