### PR TITLE
Bump version of demo app to 5.0.5

### DIFF
--- a/helm/ffc-demo-apply-web/Chart.yaml
+++ b/helm/ffc-demo-apply-web/Chart.yaml
@@ -5,5 +5,5 @@ name: ffc-demo-apply-web
 version: 1.0.0
 dependencies:
 - name: ffc-helm-library
-  version: 4.7.7
+  version: 5.0.5
   repository: https://raw.githubusercontent.com/defra/ffc-helm-repository/master/


### PR DESCRIPTION
Bump the version off ffc-helm-library to 5.0.5 to include the ingress controller changes. 